### PR TITLE
added keywords.py and keywordsV2.py

### DIFF
--- a/keywords.py
+++ b/keywords.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# File name: keywords.py
+# Description: abowcut/keywords 
+
+import gzip
+import xml.etree.ElementTree as ET
+
+
+# Read gzip XML and created nested list of Keyword Groups
+def parse_xml(xml):    
+    f = gzip.open(xml, 'rb')
+    kl = [str(kw.text).split(' -')[0].split() for kw in ET.parse(f).getroot().iter('Keyword')]
+    f.close()
+
+    return kl
+
+# Create first level mappings
+def map_first_relations(parsed_words):
+    r = {}
+    for k in parsed_words:
+        for i in k:
+            if i not in r : r[i] = {}
+            for x in list(filter(lambda a: a != i, k)):
+                r[i][x] = 1 if x not in r[i] else r[i][x]+1
+            r[i] = {m: v for m, v in sorted(r[i].items(), key=lambda item: item[1], reverse=True)}
+    
+    return r
+
+# Create Nth level mappings
+def map_n_relations(data, n):
+    for q in range(n-1):
+        for k in data:
+            if isinstance(data[k], list) == False: data[k] = [data[k]] + [{} for i in range(n-1)]
+            for m in data[k][q]:
+                if isinstance(data[m], list) == False: data[m] = [data[m]] + [{} for i in range(n-1)]
+                p = {k:1}
+                [p.update(data[k][n]) for n in range(q+1)]
+                for i in list(filter(lambda a: a not in p, data[m][0])):
+                    data[k][q+1][i] = 1 if i not in data[k][q+1] else data[k][q+1][i]+1
+            data[k][q+1] = {m: v for m, v in sorted(data[k][q+1].items(), key=lambda item: item[1], reverse=True)}
+    
+    return data
+
+# Turn the results dictionary into an XML readable string and save to local directory
+def results_to_xml(data):
+    er = ''
+    for i in data:
+        xml = '\n\t<Item>\n\t\t<Keyword>{0}</Keyword>'.format(i)
+        for m, t in enumerate(data[i]):
+            xml += '\n\t\t<{0}degree>{1}</{0}degree>'.format(m+1,t)
+        xml += '\n\t</Item>'
+        er += xml
+    er = '<ItemList>{0}\n</ItemList>'.format(er)
+    f = open("Results.xml", "wb")
+    f.write(er.encode())
+    f.close()
+    print('Saved Results.xml to local directory')
+
+# Main Function (Begin Here)
+def main():
+    keyword_list = parse_xml('keywords.xml.gz')
+    res = map_first_relations(keyword_list)
+    end = map_n_relations(res, 3)
+    results_to_xml(end)
+
+
+if __name__ == '__main__':
+    main()

--- a/keywordsV2.py
+++ b/keywordsV2.py
@@ -1,0 +1,38 @@
+import gzip
+import xml.etree.ElementTree as ET
+
+# Read gzip XML and created nested list of Keyword Groups
+f = gzip.open('keywords.xml.gz', 'rb')
+kl = [str(kw.text).split(' -')[0].split() for kw in ET.parse(f).getroot().iter('Keyword')]
+f.close()
+
+# Global Constants
+r1 = {}
+r2 = {}
+r3 = {}
+er = ''
+
+# Get 1st, 2nd, 3rd Keyword Relations
+[r1.update({(q := i.copy()).pop(c):q}) if k not in r1 else r1.update({(q := i.copy()).pop(c):q+r1[k]}) for i in kl for c, k in enumerate(i)]
+[r2.update({i:(q := list(filter(lambda a: a not in r1[i] and a != i,r1[x])))}) if i not in r2 else r2.update({i:r2[i]+(q := list(filter(lambda a: a not in r1[i] and a != i,r1[x])))}) for i in r1 for x in set(r1[i])]
+[r3.update({i:(q := list(filter(lambda a: a not in r1[i] and a not in r2[i] and a != i,r1[x])))}) if i not in r3 else r3.update({i:r3[i]+(q := list(filter(lambda a: a not in r1[i] and a not in r2[i] and a != i,r1[x])))}) for i in r1 for x in set(r2[i])]
+
+# Count occurrences and sort by count
+for r in [r1,r2,r3]:
+    for i in r:
+        r[i] = dict(zip(r[i],list(map(lambda x: r[i].count(x), r[i]))))
+        r[i] = {k: v for k, v in sorted(r[i].items(), key=lambda item: item[1], reverse=True)}
+
+# # Turn the results dictionary into an XML readable string
+for i in r1:
+    xml = """\n\t<Item>\n\t\t<Keyword>{0}</Keyword>""".format(i)
+    for c, r in enumerate([r1,r2,r3]):
+        xml += '\n\t\t<{0}degree>{1}</{0}degree>'.format(c+1,r[i])
+    xml += '\n\t</Item>'
+    er += xml
+er = '<ItemList>{0}\n</ItemList>'.format(er)
+
+# # Save r1 string into a new xml file within the directory
+f = open("Results.xml", "wb")
+f.write(er.encode())
+f.close()


### PR DESCRIPTION
keywordsV2 was an experiment I was playing around with. Essentially I was trying to see how little lines of code I could do it in. It works, however, is extremely more computationally expensive compared to keywords.py which is surprising given that keywords.py has a Big O of n^4.
 
I know this wasn't specified in the readme but I also strayed away from helpful libraries besides the libraries needed to read the gzip and parse the xml to stay true to the data structures challenge of a project like this. If not restricted, it would be helpful to use libraries such as numpy to help create n-dimensional arrays and matrices and Collections to add values of dictionaries together, etc.

While the first relations mapping is quite different since all other relations are based on the each keywords relative first relations, I made it so that the function map_n_relations() can hypothetically create relations for the Nth number (whatever you pass into the second parameter) and not just to the third relation.

Looking forward to going through this with you! If you have a solution you've built out, I'd love to see it.

Alec